### PR TITLE
Feature: fetchPriority hints

### DIFF
--- a/PictureRenderer/Constants.cs
+++ b/PictureRenderer/Constants.cs
@@ -25,4 +25,12 @@ namespace PictureRenderer
         Auto,
         None
     }
+
+    public enum FetchPriority
+    {
+        None,
+        Auto,
+        Low,
+        High,
+    }
 }

--- a/PictureRenderer/Picture.cs
+++ b/PictureRenderer/Picture.cs
@@ -105,8 +105,9 @@ namespace PictureRenderer
             var loadingAttribute = lazyLoading == LazyLoading.Browser ? "loading=\"lazy\" " : string.Empty;
             var classAttribute = string.IsNullOrEmpty(pictureData.CssClass) ? string.Empty : $"class=\"{HttpUtility.HtmlEncode(pictureData.CssClass)}\"";
             var decodingAttribute = profile.ImageDecoding == ImageDecoding.None ? string.Empty :  $"decoding=\"{Enum.GetName(typeof(ImageDecoding), profile.ImageDecoding)?.ToLower()}\" ";
+            var fetchPriorityAttribute = profile.FetchPriority == FetchPriority.None ? string.Empty :  $"fetchPriority=\"{Enum.GetName(typeof(FetchPriority), profile.FetchPriority)?.ToLower()}\" ";
 
-            return $"<img{idAttribute} alt=\"{HttpUtility.HtmlEncode(pictureData.AltText)}\" src=\"{pictureData.ImgSrc}\" {widthAndHeightAttributes}{loadingAttribute}{decodingAttribute}{classAttribute}/>";
+            return $"<img{idAttribute} alt=\"{HttpUtility.HtmlEncode(pictureData.AltText)}\" src=\"{pictureData.ImgSrc}\" {widthAndHeightAttributes}{loadingAttribute}{decodingAttribute}{fetchPriorityAttribute}{classAttribute}/>";
         }
 
         private static string GetImgWidthAndHeightAttributes(PictureProfileBase profile, string imgWidth)

--- a/PictureRenderer/PictureRenderer.csproj
+++ b/PictureRenderer/PictureRenderer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.8</Version>
+    <Version>3.9</Version>
     <Authors>Erik Henningson</Authors>
     <Company />
     <Product />

--- a/PictureRenderer/Profiles/PictureProfileBase.cs
+++ b/PictureRenderer/Profiles/PictureProfileBase.cs
@@ -68,7 +68,7 @@ namespace PictureRenderer.Profiles
         public ImageDecoding ImageDecoding {get; set;}
 
         /// <summary>
-        /// Img element decoding attribute.
+        /// Img element fetchPriority attribute.
         /// </summary>
         public FetchPriority FetchPriority {get; set;}
 

--- a/PictureRenderer/Profiles/PictureProfileBase.cs
+++ b/PictureRenderer/Profiles/PictureProfileBase.cs
@@ -67,6 +67,11 @@ namespace PictureRenderer.Profiles
         /// </summary>
         public ImageDecoding ImageDecoding {get; set;}
 
+        /// <summary>
+        /// Img element decoding attribute.
+        /// </summary>
+        public FetchPriority FetchPriority {get; set;}
+
         public bool ShowInfo { get; set; }
 
 

--- a/PictureRendererTests/ImageSharpTests.cs
+++ b/PictureRendererTests/ImageSharpTests.cs
@@ -72,6 +72,78 @@ namespace PictureRenderer.Tests
         }
 
         [Fact()]
+        public void RenderWithWidthAndHeightAndFetchPriorityNone()
+        {
+            const string expected = "<picture><source srcset=\"/myImage.jpg?format=webp&width=150&height=150&quality=80 150w, /myImage.jpg?format=webp&width=300&height=300&quality=80 300w\" sizes=\"150px\" type=\"image/webp\"/><source srcset=\"/myImage.jpg?width=150&height=150&quality=80 150w, /myImage.jpg?width=300&height=300&quality=80 300w\" sizes=\"150px\" /><img alt=\"alt text\" src=\"/myImage.jpg?width=300&height=300&quality=80\" width=\"300\" height=\"300\" loading=\"lazy\" decoding=\"async\" /></picture>";
+            var profile = new ImageSharpProfile()
+            {
+                SrcSetWidths = new[] { 150, 300 },
+                Sizes = new[] { "150px" },
+                AspectRatio = 1,
+                ImgWidthHeight = true,
+                FetchPriority = FetchPriority.None,
+            };
+
+            var result = PictureRenderer.Picture.Render("/myImage.jpg", profile, "alt text");
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact()]
+        public void RenderWithWidthAndHeightAndFetchPriorityAuto()
+        {
+            const string expected = "<picture><source srcset=\"/myImage.jpg?format=webp&width=150&height=150&quality=80 150w, /myImage.jpg?format=webp&width=300&height=300&quality=80 300w\" sizes=\"150px\" type=\"image/webp\"/><source srcset=\"/myImage.jpg?width=150&height=150&quality=80 150w, /myImage.jpg?width=300&height=300&quality=80 300w\" sizes=\"150px\" /><img alt=\"alt text\" src=\"/myImage.jpg?width=300&height=300&quality=80\" width=\"300\" height=\"300\" loading=\"lazy\" decoding=\"async\" fetchPriority=\"auto\" /></picture>";
+            var profile = new ImageSharpProfile()
+            {
+                SrcSetWidths = new[] { 150, 300 },
+                Sizes = new[] { "150px" },
+                AspectRatio = 1,
+                ImgWidthHeight = true,
+                FetchPriority = FetchPriority.Auto,
+            };
+
+            var result = PictureRenderer.Picture.Render("/myImage.jpg", profile, "alt text");
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact()]
+        public void RenderWithWidthAndHeightAndFetchPriorityHigh()
+        {
+            const string expected = "<picture><source srcset=\"/myImage.jpg?format=webp&width=150&height=150&quality=80 150w, /myImage.jpg?format=webp&width=300&height=300&quality=80 300w\" sizes=\"150px\" type=\"image/webp\"/><source srcset=\"/myImage.jpg?width=150&height=150&quality=80 150w, /myImage.jpg?width=300&height=300&quality=80 300w\" sizes=\"150px\" /><img alt=\"alt text\" src=\"/myImage.jpg?width=300&height=300&quality=80\" width=\"300\" height=\"300\" loading=\"lazy\" decoding=\"async\" fetchPriority=\"high\" /></picture>";
+            var profile = new ImageSharpProfile()
+            {
+                SrcSetWidths = new[] { 150, 300 },
+                Sizes = new[] { "150px" },
+                AspectRatio = 1,
+                ImgWidthHeight = true,
+                FetchPriority = FetchPriority.High,
+            };
+
+            var result = PictureRenderer.Picture.Render("/myImage.jpg", profile, "alt text");
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact()]
+        public void RenderWithWidthAndHeightAndFetchPriorityLow()
+        {
+            const string expected = "<picture><source srcset=\"/myImage.jpg?format=webp&width=150&height=150&quality=80 150w, /myImage.jpg?format=webp&width=300&height=300&quality=80 300w\" sizes=\"150px\" type=\"image/webp\"/><source srcset=\"/myImage.jpg?width=150&height=150&quality=80 150w, /myImage.jpg?width=300&height=300&quality=80 300w\" sizes=\"150px\" /><img alt=\"alt text\" src=\"/myImage.jpg?width=300&height=300&quality=80\" width=\"300\" height=\"300\" loading=\"lazy\" decoding=\"async\" fetchPriority=\"low\" /></picture>";
+            var profile = new ImageSharpProfile()
+            {
+                SrcSetWidths = new[] { 150, 300 },
+                Sizes = new[] { "150px" },
+                AspectRatio = 1,
+                ImgWidthHeight = true,
+                FetchPriority = FetchPriority.Low,
+            };
+
+            var result = PictureRenderer.Picture.Render("/myImage.jpg", profile, "alt text");
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact()]
         public void RenderWithFixedHeight()
         {
             const string expected = "<picture><source srcset=\"/myImage.jpg?format=webp&width=150&height=100&quality=80 150w, /myImage.jpg?format=webp&width=300&height=100&quality=80 300w\" sizes=\"150px\" type=\"image/webp\"/><source srcset=\"/myImage.jpg?width=150&height=100&quality=80 150w, /myImage.jpg?width=300&height=100&quality=80 300w\" sizes=\"150px\" /><img alt=\"alt text\" src=\"/myImage.jpg?width=300&height=100&quality=80\" width=\"300\" height=\"100\" loading=\"lazy\" decoding=\"async\" /></picture>";

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ public static class PictureProfiles
 * **ImageDecoding (optional)** - Value for img element `decoding` attribute. Default value: `async`.
 * **ImgWidthHeight (optional)** - If true, `width` and `height` attributes will be rendered on the img element.
 * **ShowInfo (optional)** - If true, an overlay will show info about the currently selected image.
+* **FetchPriority (optional)** - Value for img element `fetchPriority` attribute. Default value: `none` (unset)
 
 ### Render picture element
 Render the picture element by calling `Picture.Render`


### PR DESCRIPTION
Hi Erik,

This pull request introduces [fetchPriority](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority) attribute - this will allow setting priority to images, improving LCP in some scenarios.
While it's not yet universally [supported](https://caniuse.com/mdn-html_elements_img_fetchpriority), it's supported in Chromium-based browsers, taking most of the current market share.
Hopefully you find it useful :)

More information:
https://web.dev/articles/fetch-priority

