### PR TITLE
Added support for UnsplashPlaceholders And <figure> wrapper

### DIFF
--- a/PictureRenderer/Picture.cs
+++ b/PictureRenderer/Picture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Web;
 using PictureRenderer.Profiles;
@@ -65,11 +66,11 @@ namespace PictureRenderer
         /// </summary>
         /// <param name="focalPoint">Value range: 0-1 for ImageSharp, 1-[image width/height] for Storyblok.</param>
         /// <returns></returns>
-        public static string Render(string imagePath, PictureProfileBase profile, string altText = "", LazyLoading lazyLoading = LazyLoading.Browser, (double x, double y) focalPoint = default, string cssClass = "", string imgWidth = "", string style = "")
+        public static string Render(string imagePath, PictureProfileBase profile, string altText = "", LazyLoading lazyLoading = LazyLoading.Browser, (double x, double y) focalPoint = default, string cssClass = "", string imgWidth = "", string style = "", string wrapClass = "")
         {
             var pictureData = PictureUtils.GetPictureData(imagePath, profile, altText, focalPoint, cssClass);
            
-            var sourceElement = RenderSourceElement(pictureData);
+            var sourceElement = RenderSourceElement(pictureData, usePlaceHolders: profile.UsePlaceholders);
 
             var sourceElementWebp = string.Empty;
             if (!string.IsNullOrEmpty(pictureData.SrcSetWebp))
@@ -78,37 +79,62 @@ namespace PictureRenderer
             }
             
             var imgElement = RenderImgElement(pictureData, profile, lazyLoading, imgWidth, style);
-            var pictureElement = $"<picture>{sourceElementWebp}{sourceElement}{imgElement}</picture>"; //Webp source element must be rendered first. Browser selects the first version it supports.
+            var pictureClassAttribute = profile.UseFigureWrap ? "" : string.IsNullOrEmpty(wrapClass) ? "" : $" class=\"{HttpUtility.HtmlEncode(wrapClass)}\"";
+            var figureClassAttribute = profile.UseFigureWrap && !string.IsNullOrEmpty(wrapClass) ? $" class=\"{HttpUtility.HtmlEncode(wrapClass)}\"" : "";
+            var pictureElement = $"<picture{pictureClassAttribute}>{sourceElementWebp}{sourceElement}{imgElement}</picture>"; //Webp source element must be rendered first. Browser selects the first version it supports.
+
             var infoElements = RenderInfoElements(profile, pictureData);
 
-            return $"{pictureElement}{infoElements}";
+            if (profile.UseFigureWrap)
+            {
+                var figcaptionElement = profile.IncludeFigcaption ? $"<figcaption>{HttpUtility.HtmlEncode(altText)}</figcaption>" : "";
+                return $"<figure{figureClassAttribute}>{pictureElement}{figcaptionElement}</figure>{infoElements}";
+            }
+            else
+            {
+                return $"{pictureElement}{infoElements}";
+            }
         }
 
         /// <summary>
         /// Render different images in the same picture element.
         /// </summary>
-        public static string Render(string[] imagePaths, PictureProfileBase profile, string altText = "", LazyLoading lazyLoading = LazyLoading.Browser, (double x, double y)[] focalPoints = null, string cssClass = "")
+        public static string Render(string[] imagePaths, PictureProfileBase profile, string altText = "", LazyLoading lazyLoading = LazyLoading.Browser, (double x, double y)[] focalPoints = null, string cssClass = "", string wrapClass = "")
         {
             var pictureData = PictureUtils.GetMultiImagePictureData(imagePaths, profile, altText, focalPoints, cssClass);
             var sourceElements = RenderSourceElementsForMultiImage(pictureData);
             var imgElement = RenderImgElement(pictureData, profile, lazyLoading, string.Empty, string.Empty);
-            var pictureElement = $"<picture>{sourceElements}{imgElement}</picture>";
+            var pictureClassAttribute = profile.UseFigureWrap ? "" : string.IsNullOrEmpty(wrapClass) ? "" : $" class=\"{HttpUtility.HtmlEncode(wrapClass)}\"";
+            var figureClassAttribute = profile.UseFigureWrap && !string.IsNullOrEmpty(wrapClass) ? $" class=\"{HttpUtility.HtmlEncode(wrapClass)}\"" : "";
+            var pictureElement = $"<picture{pictureClassAttribute}>{sourceElements}{imgElement}</picture>";
+
+
             var infoElements = RenderInfoElements(profile, pictureData);
 
-            return $"{pictureElement}{infoElements}";
+            if (profile.UseFigureWrap)
+            {
+                var figcaptionElement = profile.IncludeFigcaption ? $"<figcaption>{HttpUtility.HtmlEncode(altText)}</figcaption>" : "";
+                return $"<figure{figureClassAttribute}>{pictureElement}{figcaptionElement}</figure>{infoElements}";
+            }
+            else
+            {
+                return $"{pictureElement}{infoElements}";
+            }
         }
 
         private static string RenderImgElement(PictureData pictureData, PictureProfileBase profile, LazyLoading lazyLoading, string imgWidth, string style)
         {
+            var imgSrc = profile.UsePlaceholders ? "https://source.unsplash.com/random/?happy" : pictureData.ImgSrc;
             var idAttribute = string.IsNullOrEmpty(pictureData.UniqueId) ? string.Empty : $" id=\"{pictureData.UniqueId}\"";
             var widthAndHeightAttributes = GetImgWidthAndHeightAttributes(profile, imgWidth);
             var loadingAttribute = lazyLoading == LazyLoading.Browser ? "loading=\"lazy\" " : string.Empty;
-            var classAttribute = string.IsNullOrEmpty(pictureData.CssClass) ? string.Empty : $"class=\"{HttpUtility.HtmlEncode(pictureData.CssClass)}\"";
+            var cssClasses = string.Join(" ", new[] { pictureData.DefaultMediaClass, pictureData.CssClass }.Where(s => !string.IsNullOrEmpty(s)));
+            var classAttribute = string.IsNullOrEmpty(cssClasses) ? string.Empty : $"class=\"{cssClasses}\"";
             var decodingAttribute = profile.ImageDecoding == ImageDecoding.None ? string.Empty :  $"decoding=\"{Enum.GetName(typeof(ImageDecoding), profile.ImageDecoding)?.ToLower()}\" ";
             var fetchPriorityAttribute = profile.FetchPriority == FetchPriority.None ? string.Empty :  $"fetchPriority=\"{Enum.GetName(typeof(FetchPriority), profile.FetchPriority)?.ToLower()}\" ";
             var styleAttribute = string.IsNullOrEmpty(style) ? string.Empty : $"style=\"{style}\" ";
 
-            return $"<img{idAttribute} alt=\"{HttpUtility.HtmlEncode(pictureData.AltText)}\" src=\"{pictureData.ImgSrc}\" {widthAndHeightAttributes}{loadingAttribute}{decodingAttribute}{fetchPriorityAttribute}{classAttribute}{styleAttribute}/>";
+            return $"<img{idAttribute} alt=\"{HttpUtility.HtmlEncode(pictureData.AltText)}\" src=\"{imgSrc}\" {widthAndHeightAttributes}{loadingAttribute}{decodingAttribute}{fetchPriorityAttribute}{classAttribute}{styleAttribute}/>";
         }
 
         private static string GetImgWidthAndHeightAttributes(PictureProfileBase profile, string imgWidth)
@@ -136,7 +162,7 @@ namespace PictureRenderer
             return string.Empty;
         }
 
-        private static string RenderSourceElement(PictureData pictureData, string format = "")
+        private static string RenderSourceElement(PictureData pictureData, string format = "", bool usePlaceHolders = false)
         {
             var srcSet = pictureData.SrcSet;
             var formatAttribute = string.Empty;
@@ -147,30 +173,51 @@ namespace PictureRenderer
             }
             var srcSetAttribute = $"srcset=\"{srcSet}\"";
             var sizesAttribute = $"sizes=\"{pictureData.SizesAttribute}\"";
-
-            return $"<source {srcSetAttribute} {sizesAttribute} {formatAttribute}/>";
+            var classAttribute = string.IsNullOrEmpty(pictureData.DefaultMediaClass) ? string.Empty : $"class=\"{HttpUtility.HtmlEncode(pictureData.DefaultMediaClass)}\"";
+            return $"<source {srcSetAttribute} {sizesAttribute} {formatAttribute} {classAttribute}/>";
         }
 
-        private static string RenderSourceElementsForMultiImage(MediaImagesPictureData pictureData)
+        private static string RenderSourceElementsForMultiImage(MediaImagesPictureData pictureData, bool usePlaceholders = false)
         {
             var sourceElementsBuilder = new StringBuilder();
+            var classAttribute = string.IsNullOrEmpty(pictureData.DefaultMediaClass) ? string.Empty : $"class=\"{HttpUtility.HtmlEncode(pictureData.DefaultMediaClass)}\"";
             foreach (var mediaImage in pictureData.MediaImages)
             {
-                var mediaAttribute = $"media=\"{mediaImage.MediaCondition}\"";
+                var srcSetSrc = usePlaceholders ? GeneratePlaceholderUrl(mediaImage.MediaCondition) : mediaImage.ImagePath;
+                var srcSetWebp = usePlaceholders ? GeneratePlaceholderUrl(mediaImage.MediaCondition) : mediaImage.ImagePathWebp;
+                var mediaAttribute = $"media=\"{mediaImage.MediaCondition}\"";                
 
                 //add webp source element first
-                if (!string.IsNullOrEmpty(mediaImage.ImagePathWebp))
+                if (!string.IsNullOrEmpty(srcSetWebp))
                 {
-                    var srcSetWebpAttribute = $"srcset=\"{mediaImage.ImagePathWebp}\"";
                     var formatAttribute = "type=\"image/webp\"";
-                    sourceElementsBuilder.Append($"<source {mediaAttribute} {srcSetWebpAttribute} {formatAttribute}/>");
+                    sourceElementsBuilder.Append($"<source {mediaAttribute} srcset=\"{srcSetWebp}\" {formatAttribute} {classAttribute}/>");
                 }
 
-                var srcSetAttribute = $"srcset=\"{mediaImage.ImagePath}\"";
-                sourceElementsBuilder.Append($"<source {mediaAttribute} {srcSetAttribute}/>");
-            }
+                var srcSetAttribute = $"srcset=\"{srcSetSrc}\"";
+                sourceElementsBuilder.Append($"<source {mediaAttribute} {srcSetAttribute} {classAttribute}/>");
+            }        
 
             return sourceElementsBuilder.ToString();
+        }
+
+        private static string GeneratePlaceholderUrl(string mediaCondition)
+        {
+            Random random = new Random();
+            var rnd = new string(Enumerable.Range(0, 5).Select(_ => (char)random.Next('a', 'z' + 1)).ToArray());
+            
+            if (mediaCondition.Contains("(min-width: 1025px)")) // Desktop
+            {
+                return "https://source.unsplash.com/random/1280x720?dog,dogs&r=" + rnd;
+            }
+            else if (mediaCondition.Contains("(min-width: 641px)") && mediaCondition.Contains("(max-width: 1024px)")) // Tablets
+            {
+                return "https://source.unsplash.com/random/1024x576?cat,cats&r=" + rnd;
+            }
+            else // Mobile and others
+            {
+                return "https://source.unsplash.com/random/896x504?bug,bugs&r=" + rnd;
+            }
         }
 
         private static string RenderInfoElements(PictureProfileBase pictureProfile,  PictureData pictureData)

--- a/PictureRenderer/PictureData.cs
+++ b/PictureRenderer/PictureData.cs
@@ -11,6 +11,7 @@
         //public string ImgSrcLowQuality { get; set; }
         public string AltText { get; set; }
         public string CssClass { get; set; }
+        public string DefaultMediaClass { get; set; }
         /// <summary>
         /// Id used when rendering picture info.
         /// </summary>

--- a/PictureRenderer/PictureUtils.cs
+++ b/PictureRenderer/PictureUtils.cs
@@ -27,6 +27,7 @@ namespace PictureRenderer
                 CssClass = cssClass,
                 SrcSet = BuildSrcSet(uri, profile, string.Empty, focalPoint),
                 SizesAttribute = string.Join(", ", profile.Sizes),
+                DefaultMediaClass = profile.DefaultMediaClass,
                 UniqueId = profile.ShowInfo ? Guid.NewGuid().ToString("n").Substring(0, 10) : string.Empty
             };
 
@@ -92,6 +93,11 @@ namespace PictureRenderer
 
         private static string BuildImageUrl(Uri uri, PictureProfileBase profile, int imageWidth, string wantedFormat, (double x, double y) focalPoint)
         {
+            if (profile.UsePlaceholders) 
+            {
+                return GeneratePlaceholderUrl(imageWidth);
+            }
+
             if (profile is ImageSharpProfile imageSharpProfile)
             {
                 return ImageSharpUrlBuilder.BuildImageUrl(uri, imageSharpProfile, imageWidth, wantedFormat, focalPoint);
@@ -108,6 +114,25 @@ namespace PictureRenderer
             }
             
             return string.Empty;
+        }
+
+        private static string GeneratePlaceholderUrl(int imageWidth)
+        {
+            Random random = new Random();
+            var rnd = new string(Enumerable.Range(0, 5).Select(_ => (char)random.Next('a', 'z' + 1)).ToArray());
+
+            if (imageWidth > 1024) // Desktop
+            {
+                return "https://source.unsplash.com/random/1280x720?dog,dogs&r=" + rnd;
+            }
+            else if (imageWidth > 641 && imageWidth < 1024) // Tablets
+            {
+                return "https://source.unsplash.com/random/1024x576?cat,cats&r=" + rnd;
+            }
+            else // Mobile and others
+            {
+                return "https://source.unsplash.com/random/896x504?bug,bugs&r=" + rnd;
+            }
         }
 
         internal static (string x, string y) FocalPointAsString((double x, double y) focalPoint)

--- a/PictureRenderer/Profiles/PictureProfileBase.cs
+++ b/PictureRenderer/Profiles/PictureProfileBase.cs
@@ -74,6 +74,25 @@ namespace PictureRenderer.Profiles
 
         public bool ShowInfo { get; set; }
 
+        /// <summary>
+        /// If true, images will be fetched from unsplash.
+        /// </summary>
+        public bool UsePlaceholders { get; set; } = false;
+
+        /// <summary>
+        /// If true, the picture-element will be wraped around a figure-element.
+        /// </summary>
+        public bool UseFigureWrap { get; set; } = false;
+
+        /// <summary>
+        /// If true and UseFigureWrap is true, the alt-text will be written to a figcaption-element.
+        /// </summary>
+        public bool IncludeFigcaption { get; set; } = false;
+
+        /// <summary>
+        /// If set, these classes will be added to the source and img element.
+        /// </summary>
+        public string DefaultMediaClass { get; set; } = "";
 
         protected PictureProfileBase()
         {


### PR DESCRIPTION
Added support for UnsplashPlaceholders with UsePlaceholders. Added option to use <figure>-wrapping element with optional figcaption. Added defaultmediaclasses for img and sourcetags as I need them with my current CSS-framework (tailwind and the classes "h-full w-full object-cover"). Also added the option to add classes in the render-method to the wrapping element, be it <figure> or <picture>, also needed by my CSS-framework ("aspect-video" for example).

